### PR TITLE
Update styling of toolbar to be responsive [Deliver #147047439]

### DIFF
--- a/src/less/toolbar.less
+++ b/src/less/toolbar.less
@@ -8,9 +8,19 @@
   align-items: center;
   margin-bottom: 10px;
   font-size: 16px;
+  justify-content: space-between;
+
+  @media (max-width: 600px) {
+    flex-wrap: wrap;
+
+    .rbc-btn-group:last-child {
+      margin-top: 0.5em;
+      width: 100%;
+    }
+  }
 
   .rbc-toolbar-label {
-    width: 100%;
+    font-weight: bold;
     padding: 0 10px;
     text-align: center;
   }


### PR DESCRIPTION
- the 600px is a bit arbitrary at the moment, as that really depends on the horizontal space available to the calendar within the browser window (i.e. how much padding/margin is around the calendar)
- stop forcing the toolbar label to have 100% width and instead specify the justify-content flexbox property for optimal spacing between the three toolbar items
- below 600px, allow wrapping in the flexbox container and force the last button group to be width 100% so that it wraps to the next line