### PR TITLE
Calculate the width of the all day events row dynamically

### DIFF
--- a/src/DateContentRow.js
+++ b/src/DateContentRow.js
@@ -41,11 +41,14 @@ const propTypes = {
   eventWrapperComponent: elementType.isRequired,
   minRows: PropTypes.number.isRequired,
   maxRows: PropTypes.number.isRequired,
+
+  style: PropTypes.object,
 };
 
 const defaultProps = {
   minRows: 0,
   maxRows: Infinity,
+  style: {},
 }
 
 class DateContentRow extends React.Component {
@@ -151,6 +154,7 @@ class DateContentRow extends React.Component {
       eventWrapperComponent,
       onSelectStart,
       onSelectEnd,
+      style,
       ...props
     } = this.props;
 
@@ -168,7 +172,7 @@ class DateContentRow extends React.Component {
     while (levels.length < minRows ) levels.push([])
 
     return (
-      <div className={className}>
+      <div className={className} style={style}>
         <BackgroundCells
           rtl={rtl}
           range={range}

--- a/test/components/DateContentRow.spec.js
+++ b/test/components/DateContentRow.spec.js
@@ -45,5 +45,18 @@ describe('<DateContentRow />', () => {
         expect(eventRow).to.have.prop('view', 'month');
       });
     });
+
+    it('passes the style prop to the root div', () => {
+      props.style = { width: 'all-of-it' };
+      const wrapper = shallow(<DateContentRow {...props} />);
+
+      expect(wrapper.find('div').first().prop('style')).to.deep.equal({ width: 'all-of-it' });
+    });
+
+    it('passes empty object as the style prop of the root div if none passed to component', () => {
+      const wrapper = shallow(<DateContentRow {...props} />);
+
+      expect(wrapper.find('div').first().prop('style')).to.deep.equal({});
+    });
   });
 });

--- a/test/components/TimeGrid.spec.js
+++ b/test/components/TimeGrid.spec.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 import React from 'react';
 import sinon from 'sinon';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import { expect } from 'chai';
 
 import * as Helpers from '../../src/utils/helpers';
@@ -11,6 +11,7 @@ import DateContentRow from '../../src/DateContentRow';
 import DayColumn from '../../src/DayColumn';
 import EventWrapper from '../../src/EventWrapper';
 import Week from '../../src/Week';
+import BackgroundWrapper from '../../src/BackgroundWrapper';
 
 import events from '../factories/events';
 
@@ -35,6 +36,7 @@ describe('<TimeGrid />', () => {
       events,
       components: {
         eventWrapper: EventWrapper,
+        dateCellWrapper: BackgroundWrapper,
       },
       range: Week.range(events[0].start, {}),
       titleAccessor,
@@ -66,12 +68,44 @@ describe('<TimeGrid />', () => {
       expect(contentRow).to.have.prop('view', 'week');
     });
 
+    it('passes style prop with correct width to DateContentRow', () => {
+      const wrapper = mount(<TimeGrid {...props} />);
+      sandbox.stub(wrapper.instance(), 'measureAllDayRowWidth').returns(200);
+      wrapper.update();
+
+      expect(wrapper.find(DateContentRow).prop('style')).to.deep.equal({ width: '200px' });
+    });
+
     it('passes view prop to DayColumn', () => {
       const wrapper = shallow(<TimeGrid {...props} />);
 
       wrapper.find(DayColumn).forEach((dayColumn) => {
         expect(dayColumn).to.have.prop('view', 'week');
       });
+    });
+
+    it('adds window resize event listener', () => {
+      sandbox.stub(window, 'addEventListener');
+      const wrapper = mount(<TimeGrid {...props} />);
+
+      sinon.assert.calledWith(window.addEventListener, 'resize', wrapper.instance().handleWindowResize);
+    });
+  });
+
+  describe('on componentWillUnmount', () => {
+    let wrapper;
+
+    beforeEach(() => {
+      wrapper = mount(<TimeGrid {...props} />);
+    });
+
+    it('removes the window resize event listener', () => {
+      const windowResizeCallback = wrapper.instance().handleWindowResize;
+      sandbox.stub(window, 'removeEventListener');
+
+      wrapper.unmount();
+
+      sinon.assert.calledWith(window.removeEventListener, 'resize', windowResizeCallback);
     });
   });
 
@@ -92,6 +126,49 @@ describe('<TimeGrid />', () => {
       wrapper.instance().handleShowMore([], date);
 
       sinon.assert.calledWith(Helpers.notify, 'agenda mock', ['mock', 'agenda']);
+    });
+  });
+
+  describe('on window resize', () => {
+    let wrapper;
+
+    beforeEach(() => {
+      wrapper = mount(<TimeGrid {...props} />);
+      wrapper.setState({ allDayRowWidth: 100, gutterWidth: 50 });
+    });
+
+    it('updates allDayRowWidth in the internal state', () => {
+      const headerCellsRow = wrapper.ref('headerCell').node;
+      sandbox.stub(headerCellsRow, 'querySelector').returns({ clientWidth: 200 });
+
+      expect(wrapper.state('allDayRowWidth')).to.equal(100);
+
+      window.dispatchEvent(new window.CustomEvent('resize'));
+
+      expect(wrapper.state('allDayRowWidth')).to.equal(150);
+    });
+
+    it('uses props.width over state.gutterWidth', () => {
+      wrapper.setProps({ width: 25 });
+      const headerCellsRow = wrapper.ref('headerCell').node;
+      sandbox.stub(headerCellsRow, 'querySelector').returns({ clientWidth: 200 });
+
+      expect(wrapper.state('allDayRowWidth')).to.equal(100);
+
+      window.dispatchEvent(new window.CustomEvent('resize'));
+
+      expect(wrapper.state('allDayRowWidth')).to.equal(175);
+    });
+
+    it('does not update allDayRowWidth if there is no rbc-row found', () => {
+      const headerCellsRow = wrapper.ref('headerCell').node;
+      sandbox.stub(headerCellsRow, 'querySelector').returns(null);
+
+      expect(wrapper.state('allDayRowWidth')).to.equal(100);
+
+      window.dispatchEvent(new window.CustomEvent('resize'));
+
+      expect(wrapper.state('allDayRowWidth')).to.equal(100);
     });
   });
 });


### PR DESCRIPTION
For some reason, when there are multiple all day events displaying for a given week, the all day events row in the calendar wont shrink past a certain size. What this means is, once you get to a small enough width for the calendar (in the app where we are using this calendar, this happens in every single breakpoint -- small, medium, and large), the events just disappear off the side of the calendar and off the side of the browser window. The more all day events you have, the sooner they stop shrinking and start going off the side of the calendar / browser window. If we just calculate the right width on the initial render (without the onresize listener), then the calendar will only look right on the initial page load. Any resizing of the browser window after that leads to the same issues, so we feel it is necessary to have the on resize listener as well.

(part of https://www.pivotaltracker.com/story/show/147727133)